### PR TITLE
Report how many threads are being used in fit_poisson_nmf

### DIFF
--- a/R/fit_poisson_nmf.R
+++ b/R/fit_poisson_nmf.R
@@ -404,7 +404,7 @@ fit_poisson_nmf <- function (X, k, fit0, numiter = 100,
       control$extrapolate)
     stop("control$extrapolate cannot be TRUE when all factors or loadings ",
          "are fixed")
-  control$nc <- initialize.multithreading(control$nc)
+  control$nc <- initialize.multithreading(control$nc,verbose != "none")
   
   # Only one of "k" and "fit0" should be provided. If argument "k" is
   # given, generate a random initialization of the factors and


### PR DESCRIPTION
Fix the call into `initialize.multithreading` after the change to quiet output.