### PR TITLE
Reduce memory usage in compute_lfc_stats_multicore

### DIFF
--- a/R/lfc.R
+++ b/R/lfc.R
@@ -104,21 +104,16 @@ compute_lfc_stats_multicore <- function (X, F, L, f0, D, U, M, lfc.stat,
   # Split the data.
   nsplit <- min(m,nsplit)
   cols   <- splitIndices(m,nsplit)
-  dat    <- vector("list",nsplit)
-  for (i in 1:nsplit) {
-    j        <- cols[[i]]
-    dat[[i]] <- list(X = X[,j,drop = FALSE],F = F[j,,drop = FALSE],f0 = f0[j])
-  }
 
   # Distribute the calculations using pblapply.
-  parlapplyf <- function (dat, L, D, U, M, lfc.stat, conf.level, rw, e)
-    compute_lfc_stats(dat$X,dat$F,L,dat$f0,D,U,M,lfc.stat,conf.level,rw,e,
+  parlapplyf <- function (c, X, F, L, f0, D, U, M, lfc.stat, conf.level, rw, e)
+    compute_lfc_stats(X[,c],F[c,],L,f0[c],D,U,M,lfc.stat,conf.level,rw,e,
                       verbose = FALSE)
   if (verbose)
     op <- pboptions(type = "txt",txt.width = 70)
   else
     op <- pboptions(type = NULL)
-  ans <- pblapply(cl = nc,dat,parlapplyf,L,D,U,M,lfc.stat,conf.level,rw,e)
+  ans <- pblapply(cl = nc,cols,parlapplyf,X,F,L,f0,D,U,M,lfc.stat,conf.level,rw,e)
   pboptions(op)
 
   # Combine the individual compute_lfc_stats outputs, and output the


### PR DESCRIPTION
This change reduces memory usage by roughly 10%.

Profiling via `mprof` using the following snippet

```R
devtools::load_all()
data(pbmc_facs)
temp <- de_analysis(pbmc_facs$fit, pbmc_facs$counts, verbose=FALSE, shrink.method='none', control=list(nc=32, nsplit=32))
```

on an AWS `c7i.8xlarge` instance yields the following usages.

On 295d7323 ![295d7323](https://github.com/stephenslab/fastTopics/assets/522165/d1c75161-0c0d-4537-b8d2-0f0e5a089641)

On g19ec112 ![g19ec112](https://github.com/stephenslab/fastTopics/assets/522165/488a6c3b-0698-4c6b-a806-88f105c7ae18): 